### PR TITLE
Typechecker: Initial implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +440,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.99.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +472,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "daggy",
+ "derive_more",
  "getrandom 0.2.15",
  "macroquad",
  "nom",
@@ -469,6 +489,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tower-lsp",
+ "typed-index-collections",
 ]
 
 [[package]]
@@ -1602,6 +1623,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1633,19 +1663,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "serde"
-version = "1.0.204"
+name = "semver"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+
+[[package]]
+name = "serde"
+version = "1.0.218"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2072,6 +2108,15 @@ name = "ttf-parser"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b3e06c9b9d80ed6b745c7159c40b311ad2916abb34a49e9be2653b90db0d8dd"
+
+[[package]]
+name = "typed-index-collections"
+version = "3.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d844b11f547a6fb9dee7ed073d9860174917a072aabe05df6ee60dbe79e7afa"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 [dependencies]
 parking_lot = { version = "0.12.3", features = ["deadlock_detection"] }
+typed-index-collections = "3.2.3"
+derive_more = "0.99"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 daggy = "0.8.0"

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -3,9 +3,21 @@ use crate::{
     types::ExprType,
 };
 
+use derive_more::{From, Into};
+use serde::{Deserialize, Serialize};
+
 use super::{raw_expr::RawExpr, Statement};
 
-pub type FunctionID = usize;
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, From, Into, Serialize, Deserialize,
+)]
+pub struct FunctionID(usize);
+
+impl FunctionID {
+    pub fn new(raw_id: usize) -> FunctionID {
+        FunctionID(raw_id)
+    }
+}
 
 ///
 /// A trait defining the contract for implementing a concrete expression

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1,17 +1,18 @@
-use crate::{interpreter::PolymorphicFunctionID, types::ExprType};
+use crate::{
+    interpreter::{PolymorphicFunctionID, VariableId},
+    types::ExprType,
+};
 
 use super::{raw_expr::RawExpr, Statement};
 
 pub type FunctionID = usize;
-
-pub type VariableID = String;
 
 ///
 /// A trait defining the contract for implementing a concrete expression
 ///  type. For instance, RawExpr or TracedExpr.
 ///
 pub trait Expr: Sized {
-    fn evaluated(self) -> RawExpr<usize>;
+    fn evaluated(self) -> RawExpr<VariableId>;
 
     fn none() -> Self;
 
@@ -38,12 +39,12 @@ pub trait Expr: Sized {
     fn polymorphic_function(value: PolymorphicFunctionID) -> Self;
 
     fn lambda(
-        vars: Vec<usize>,
-        stmts: Vec<Statement<usize>>,
+        vars: Vec<VariableId>,
+        stmts: Vec<Statement<VariableId>>,
         body: Self,
     ) -> Self;
 
     fn apply<const N: usize>(fun: Self, args: [Self; N]) -> Self;
 
-    fn var(value: usize) -> Self;
+    fn var(value: VariableId) -> Self;
 }

--- a/src/ast/raw_expr.rs
+++ b/src/ast/raw_expr.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     debugging::{Debugger, NoOpDebugger},
-    interpreter::{Context, PolymorphicFunctionID},
+    interpreter::{Context, PolymorphicFunctionID, VariableId},
     modules::{ModuleName, QualifiedName},
     parser::CodeLocation,
     stdlib::ef3r_stdlib,
@@ -273,7 +273,7 @@ impl<V: Clone> RawExpr<V> {
     }
 }
 
-impl RawExpr<usize> {
+impl RawExpr<VariableId> {
     ///
     /// Utility to help build an expression for a function
     ///  resolving it by name.
@@ -281,7 +281,7 @@ impl RawExpr<usize> {
     pub fn resolve<T: Debugger + 'static>(
         context: &Context<T>,
         name: &str,
-    ) -> RawExpr<usize> {
+    ) -> RawExpr<VariableId> {
         let poly_id = context
             .expression_context
             .read()
@@ -532,8 +532,8 @@ pub fn substitute_statement<V: Clone + PartialEq + Eq>(
     }
 }
 
-impl Expr for RawExpr<usize> {
-    fn evaluated(self) -> RawExpr<usize> {
+impl Expr for RawExpr<VariableId> {
+    fn evaluated(self) -> RawExpr<VariableId> {
         self
     }
 
@@ -622,8 +622,8 @@ impl Expr for RawExpr<usize> {
     }
 
     fn lambda(
-        vars: Vec<usize>,
-        stmts: Vec<Statement<usize>>,
+        vars: Vec<VariableId>,
+        stmts: Vec<Statement<VariableId>>,
         body: Self,
     ) -> Self {
         RawExpr {
@@ -639,7 +639,7 @@ impl Expr for RawExpr<usize> {
         }
     }
 
-    fn var(value: usize) -> Self {
+    fn var(value: VariableId) -> Self {
         RawExpr {
             location: None,
             expr: RawExprRec::Var(value),

--- a/src/ast/traced_expr.rs
+++ b/src/ast/traced_expr.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     debugging::{Debugger, NoOpDebugger},
-    interpreter::{Context, PolymorphicFunctionID},
+    interpreter::{Context, PolymorphicFunctionID, VariableId},
     modules::{ModuleName, QualifiedName},
     parser::CodeLocation,
     stdlib::ef3r_stdlib,
@@ -104,7 +104,7 @@ impl<V: Clone> TracedExpr<V> {
     }
 }
 
-impl TracedExpr<usize> {
+impl TracedExpr<VariableId> {
     ///
     /// Utility to help build an expression for a function
     ///  resolving it by name.
@@ -112,7 +112,7 @@ impl TracedExpr<usize> {
     pub fn resolve<T: Debugger + 'static>(
         context: &Context<T>,
         name: &str,
-    ) -> TracedExpr<usize> {
+    ) -> TracedExpr<VariableId> {
         let poly_id = &context
             .expression_context
             .read()
@@ -130,8 +130,8 @@ impl TracedExpr<usize> {
     }
 }
 
-impl Expr for TracedExpr<usize> {
-    fn evaluated(self) -> RawExpr<usize> {
+impl Expr for TracedExpr<VariableId> {
+    fn evaluated(self) -> RawExpr<VariableId> {
         self.untraced()
     }
 
@@ -184,8 +184,8 @@ impl Expr for TracedExpr<usize> {
     }
 
     fn lambda(
-        vars: Vec<usize>,
-        stmts: Vec<Statement<usize>>,
+        vars: Vec<VariableId>,
+        stmts: Vec<Statement<VariableId>>,
         body: Self,
     ) -> Self {
         TracedExpr::new(TracedExprRec::Lambda(vars, stmts, Box::new(body)))
@@ -195,7 +195,7 @@ impl Expr for TracedExpr<usize> {
         TracedExpr::new(TracedExprRec::Apply(Box::new(fun), Box::new(args)))
     }
 
-    fn var(value: usize) -> Self {
+    fn var(value: VariableId) -> Self {
         TracedExpr::new(TracedExprRec::Var(value))
     }
 }

--- a/src/ast/traced_expr.rs
+++ b/src/ast/traced_expr.rs
@@ -342,7 +342,7 @@ impl TracedExprRec<QualifiedName> {
                 } else {
                     usize::arbitrary(g) % keys
                 };
-                TracedExprRec::BuiltinFunction(key)
+                TracedExprRec::BuiltinFunction(FunctionID::new(key))
             }
             5 => TracedExprRec::Lambda(
                 Vec::arbitrary(g),

--- a/src/executable.rs
+++ b/src/executable.rs
@@ -140,8 +140,7 @@ fn get_stdlib_polymorphic_functions<'a, T: Debugger + 'static>(
         .flat_map(|(id, func_id)| {
             let polymorphic_function = &expression_context.functions[*func_id];
             let module = &polymorphic_function.0;
-            let polymorhpic_fn_name =
-                &polymorphic_function.1.name.as_str().clone();
+            let polymorhpic_fn_name = &polymorphic_function.1.name.as_str();
 
             let symbol_id = expression_context.symbol_table.get_by_right(
                 &QualifiedName {

--- a/src/extern_utils.rs
+++ b/src/extern_utils.rs
@@ -1,7 +1,6 @@
 use crate::{
     ast::traced_expr::{TracedExpr, TracedExprRec},
     interpreter::VariableId,
-    typechecking::TypingContext,
     types::ExprType,
 };
 

--- a/src/extern_utils.rs
+++ b/src/extern_utils.rs
@@ -1,6 +1,7 @@
 use crate::{
     ast::traced_expr::{TracedExpr, TracedExprRec},
     interpreter::VariableId,
+    typechecking::TypingContext,
     types::ExprType,
 };
 
@@ -143,6 +144,7 @@ macro_rules! build_function {
                         expected: <$type>::expr_type(),
                         actual: type_of(
                             &$ctx.expression_context.read(),
+                            &TypingContext::new(),
                             &expr.evaluated,
                         )
                         .unwrap_or(ExprType::Any),
@@ -183,6 +185,7 @@ macro_rules! build_function {
                         expected: <$type1>::expr_type(),
                         actual: type_of(
                             &$ctx.expression_context.read(),
+                            &TypingContext::new(),
                             &expr1.evaluated,
                         )
                         .unwrap_or(ExprType::Any),
@@ -195,6 +198,7 @@ macro_rules! build_function {
                         expected: <$type2>::expr_type(),
                         actual: type_of(
                             &$ctx.expression_context.read(),
+                            &TypingContext::new(),
                             &expr2.evaluated,
                         )
                         .unwrap_or(ExprType::Any),

--- a/src/extern_utils.rs
+++ b/src/extern_utils.rs
@@ -1,15 +1,16 @@
 use crate::{
     ast::traced_expr::{TracedExpr, TracedExprRec},
+    interpreter::VariableId,
     types::ExprType,
 };
 
 /// Trait to map Rust types to ExprTypes
 pub trait ExprTypeable {
     fn expr_type() -> ExprType;
-    fn try_from_expr(expr: &TracedExprRec<usize>) -> Option<Self>
+    fn try_from_expr(expr: &TracedExprRec<VariableId>) -> Option<Self>
     where
         Self: Sized;
-    fn to_expr(self) -> TracedExprRec<usize>;
+    fn to_expr(self) -> TracedExprRec<VariableId>;
 }
 
 // Implementations for basic types
@@ -17,14 +18,14 @@ impl ExprTypeable for i32 {
     fn expr_type() -> ExprType {
         ExprType::Int
     }
-    fn try_from_expr(expr: &TracedExprRec<usize>) -> Option<Self> {
+    fn try_from_expr(expr: &TracedExprRec<VariableId>) -> Option<Self> {
         if let TracedExprRec::Int(x) = expr {
             Some(*x)
         } else {
             None
         }
     }
-    fn to_expr(self) -> TracedExprRec<usize> {
+    fn to_expr(self) -> TracedExprRec<VariableId> {
         TracedExprRec::Int(self)
     }
 }
@@ -33,14 +34,14 @@ impl ExprTypeable for f32 {
     fn expr_type() -> ExprType {
         ExprType::Float
     }
-    fn try_from_expr(expr: &TracedExprRec<usize>) -> Option<Self> {
+    fn try_from_expr(expr: &TracedExprRec<VariableId>) -> Option<Self> {
         if let TracedExprRec::Float(x) = expr {
             Some(*x)
         } else {
             None
         }
     }
-    fn to_expr(self) -> TracedExprRec<usize> {
+    fn to_expr(self) -> TracedExprRec<VariableId> {
         TracedExprRec::Float(self)
     }
 }
@@ -49,14 +50,14 @@ impl ExprTypeable for String {
     fn expr_type() -> ExprType {
         ExprType::String
     }
-    fn try_from_expr(expr: &TracedExprRec<usize>) -> Option<Self> {
+    fn try_from_expr(expr: &TracedExprRec<VariableId>) -> Option<Self> {
         if let TracedExprRec::String(x) = expr {
             Some(x.clone())
         } else {
             None
         }
     }
-    fn to_expr(self) -> TracedExprRec<usize> {
+    fn to_expr(self) -> TracedExprRec<VariableId> {
         TracedExprRec::String(self)
     }
 }
@@ -65,14 +66,14 @@ impl ExprTypeable for bool {
     fn expr_type() -> ExprType {
         ExprType::Bool
     }
-    fn try_from_expr(expr: &TracedExprRec<usize>) -> Option<Self> {
+    fn try_from_expr(expr: &TracedExprRec<VariableId>) -> Option<Self> {
         if let TracedExprRec::Bool(x) = expr {
             Some(*x)
         } else {
             None
         }
     }
-    fn to_expr(self) -> TracedExprRec<usize> {
+    fn to_expr(self) -> TracedExprRec<VariableId> {
         TracedExprRec::Bool(self)
     }
 }
@@ -81,42 +82,42 @@ impl ExprTypeable for () {
     fn expr_type() -> ExprType {
         ExprType::Unit
     }
-    fn try_from_expr(expr: &TracedExprRec<usize>) -> Option<Self> {
+    fn try_from_expr(expr: &TracedExprRec<VariableId>) -> Option<Self> {
         if let TracedExprRec::Unit = expr {
             Some(())
         } else {
             None
         }
     }
-    fn to_expr(self) -> TracedExprRec<usize> {
+    fn to_expr(self) -> TracedExprRec<VariableId> {
         TracedExprRec::Unit
     }
 }
 
-impl ExprTypeable for Vec<TracedExpr<usize>> {
+impl ExprTypeable for Vec<TracedExpr<VariableId>> {
     fn expr_type() -> ExprType {
         ExprType::List(Box::new(ExprType::Any))
     }
-    fn try_from_expr(expr: &TracedExprRec<usize>) -> Option<Self> {
+    fn try_from_expr(expr: &TracedExprRec<VariableId>) -> Option<Self> {
         if let TracedExprRec::List(x) = expr {
             Some(x.clone())
         } else {
             None
         }
     }
-    fn to_expr(self) -> TracedExprRec<usize> {
+    fn to_expr(self) -> TracedExprRec<VariableId> {
         TracedExprRec::List(self)
     }
 }
 
-impl ExprTypeable for TracedExprRec<usize> {
+impl ExprTypeable for TracedExprRec<VariableId> {
     fn expr_type() -> ExprType {
         ExprType::Any
     }
-    fn try_from_expr(expr: &TracedExprRec<usize>) -> Option<Self> {
+    fn try_from_expr(expr: &TracedExprRec<VariableId>) -> Option<Self> {
         Some(expr.clone())
     }
-    fn to_expr(self) -> TracedExprRec<usize> {
+    fn to_expr(self) -> TracedExprRec<VariableId> {
         self
     }
 }
@@ -128,7 +129,7 @@ macro_rules! build_function {
             argument_types: vec![<$type>::expr_type()],
             result_type: $res_type,
             name: $name.to_string(),
-            definition: |$ctx, xs: &[TracedExpr<usize>]| {
+            definition: |$ctx, xs: &[TracedExpr<VariableId>]| {
                 let expr = xs.get(0).ok_or(
                     EvaluationError::WrongNumberOfArguments {
                         expected: 1,
@@ -140,7 +141,7 @@ macro_rules! build_function {
                 let $param = <$type>::try_from_expr(&expr.evaluated).ok_or(
                     EvaluationError::TypeError {
                         expected: <$type>::expr_type(),
-                        actual: type_of::<_, _, RuntimeLookup>(
+                        actual: type_of(
                             &$ctx.expression_context.read(),
                             &expr.evaluated,
                         )
@@ -160,7 +161,7 @@ macro_rules! build_function {
             name: $name.to_string(),
             argument_types: vec![<$type1>::expr_type(), <$type2>::expr_type()],
             result_type: $res_type,
-            definition: |$ctx, xs: &[TracedExpr<usize>]| {
+            definition: |$ctx, xs: &[TracedExpr<VariableId>]| {
                 let expr1 = xs.get(0).ok_or(
                     EvaluationError::WrongNumberOfArguments {
                         expected: 2,
@@ -180,7 +181,7 @@ macro_rules! build_function {
                 let $param1 = <$type1>::try_from_expr(&expr1.evaluated).ok_or(
                     EvaluationError::TypeError {
                         expected: <$type1>::expr_type(),
-                        actual: type_of::<_, _, RuntimeLookup>(
+                        actual: type_of(
                             &$ctx.expression_context.read(),
                             &expr1.evaluated,
                         )
@@ -192,7 +193,7 @@ macro_rules! build_function {
                 let $param2 = <$type2>::try_from_expr(&expr2.evaluated).ok_or(
                     EvaluationError::TypeError {
                         expected: <$type2>::expr_type(),
-                        actual: type_of::<_, _, RuntimeLookup>(
+                        actual: type_of(
                             &$ctx.expression_context.read(),
                             &expr2.evaluated,
                         )
@@ -212,7 +213,7 @@ macro_rules! build_function {
             name: $name.to_string(),
             argument_types: $arg_types,
             result_type: $res_type,
-            definition: |$ctx, xs: &[TracedExpr<usize>]| {
+            definition: |$ctx, xs: &[TracedExpr<VariableId>]| {
                 let $param = xs
                     .get(0)
                     .ok_or(EvaluationError::WrongNumberOfArguments {
@@ -233,7 +234,7 @@ macro_rules! build_function {
             name: $name.to_string(),
             argument_types: $arg_types,
             result_type: $res_type,
-            definition: |$ctx, xs: &[TracedExpr<usize>]| {
+            definition: |$ctx, xs: &[TracedExpr<VariableId>]| {
                 let $param1 = xs
                     .get(0)
                     .ok_or(EvaluationError::WrongNumberOfArguments {
@@ -263,7 +264,7 @@ macro_rules! build_function {
             name: $name.to_string(),
             argument_types: $arg_types,
             result_type: $res_type,
-            definition: |$ctx, xs: &[TracedExpr<usize>]| {
+            definition: |$ctx, xs: &[TracedExpr<VariableId>]| {
                 let $param1 = xs
                     .get(0)
                     .ok_or(EvaluationError::WrongNumberOfArguments {

--- a/src/frp.rs
+++ b/src/frp.rs
@@ -14,7 +14,7 @@ use crate::{
     ast::traced_expr::TracedExpr,
     debugging::Debugger,
     interpreter::{Context, VariableId},
-    typechecking::type_of,
+    typechecking::{type_of, TypingContext},
     types::ExprType,
 };
 
@@ -380,6 +380,7 @@ pub fn fold_node<'a, T: Debugger + Send + Sync + 'static>(
     let new_node = Node {
         expr_type: type_of(
             &ctx.expression_context.read(),
+            &TypingContext::new(),
             &initial_clone.evaluated,
         )
         .unwrap(),

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -16,7 +16,7 @@ use crate::{
     debugging::Debugger,
     frp::Node,
     modules::{Module, ModuleData, ModuleName, QualifiedName},
-    typechecking::type_of,
+    typechecking::{type_of, TypingContext},
     types::ExprType,
 };
 
@@ -149,7 +149,6 @@ impl Display for VariableId {
     }
 }
 
-#[derive(Clone)]
 pub struct ExpressionContext<T: Debugger + 'static> {
     pub symbol_table: BiMap<VariableId, QualifiedName>,
     pub functions: Vec<(ModuleName, FunctionDefinition<T>)>,
@@ -811,7 +810,11 @@ fn function_from_expression<T: Debugger + 'static>(
             let arg_types: Vec<_> = evaluated_args
                 .iter()
                 .map(|arg| {
-                    type_of(&ctx.expression_context.read(), &arg.evaluated)
+                    type_of(
+                        &ctx.expression_context.read(),
+                        &TypingContext::new(),
+                        &arg.evaluated,
+                    )
                 })
                 .collect();
 

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,8 +1,9 @@
-use std::{collections::HashMap, sync::Arc, thread::JoinHandle};
+use std::{collections::HashMap, fmt::Display, sync::Arc, thread::JoinHandle};
 
 use bimap::{BiHashMap, BiMap};
 use daggy::Dag;
 use parking_lot::{Mutex, RwLock};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
@@ -15,7 +16,7 @@ use crate::{
     debugging::Debugger,
     frp::Node,
     modules::{Module, ModuleData, ModuleName, QualifiedName},
-    typechecking::{type_of, RuntimeLookup},
+    typechecking::type_of,
     types::ExprType,
 };
 
@@ -112,8 +113,9 @@ pub struct FunctionDefinition<T: Debugger + 'static> {
     pub result_type: ExprType,
     pub definition: fn(
         &Context<T>,
-        &[TracedExpr<usize>],
-    ) -> Result<TracedExprRec<usize>, EvaluationError>,
+        &[TracedExpr<VariableId>],
+    )
+        -> Result<TracedExprRec<VariableId>, EvaluationError>,
     pub name: String,
 }
 
@@ -125,19 +127,41 @@ pub struct PolymorphicIndex {
     pub arg_types: Vec<ExprType>,
 }
 
+#[derive(Copy, Clone, Hash, PartialEq, Eq, Debug, Serialize, Deserialize)]
+pub struct VariableId(usize);
+
+impl VariableId {
+    pub fn new<T: Debugger>(
+        ctx: &mut ExpressionContext<T>,
+        x: QualifiedName,
+    ) -> VariableId {
+        let id = VariableId(ctx.symbol_table.len());
+
+        ctx.symbol_table.insert(id, x);
+
+        id
+    }
+}
+
+impl Display for VariableId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 #[derive(Clone)]
 pub struct ExpressionContext<T: Debugger + 'static> {
-    pub symbol_table: BiMap<usize, QualifiedName>,
+    pub symbol_table: BiMap<VariableId, QualifiedName>,
     pub functions: Vec<(ModuleName, FunctionDefinition<T>)>,
     pub polymorphic_functions: HashMap<PolymorphicIndex, FunctionID>,
-    pub variables: HashMap<usize, TracedExpr<usize>>,
+    pub variables: HashMap<VariableId, TracedExpr<VariableId>>,
 }
 
 impl<T: Debugger + 'static> ExpressionContext<T> {
     ///
     /// Resolve the function ID corresponding to the passed name.
     ///
-    pub fn resolve_function(&self, name: &str) -> Option<usize> {
+    pub fn resolve_function(&self, name: &str) -> Option<FunctionID> {
         for (index, function) in self.functions.iter().enumerate() {
             if function.1.name == name {
                 return Some(index);
@@ -170,7 +194,7 @@ impl<T: Debugger + 'static> ExpressionContext<T> {
     pub fn strip_symbols(
         &mut self,
         expr: TracedExprRec<QualifiedName>,
-    ) -> TracedExprRec<usize> {
+    ) -> TracedExprRec<VariableId> {
         match expr {
             TracedExprRec::None => TracedExprRec::None,
             TracedExprRec::Unit => TracedExprRec::Unit,
@@ -201,11 +225,7 @@ impl<T: Debugger + 'static> ExpressionContext<T> {
                     .into_iter()
                     .map(|var| match self.symbol_table.get_by_right(&var) {
                         Some(id) => *id,
-                        None => {
-                            let id = self.symbol_table.len();
-                            self.symbol_table.insert(id, var);
-                            id
-                        }
+                        None => VariableId::new(self, var),
                     })
                     .collect();
 
@@ -229,11 +249,7 @@ impl<T: Debugger + 'static> ExpressionContext<T> {
             TracedExprRec::Var(x) => {
                 TracedExprRec::Var(match self.symbol_table.get_by_right(&x) {
                     Some(id) => *id,
-                    None => {
-                        let id = self.symbol_table.len();
-                        self.symbol_table.insert(id, x);
-                        id
-                    }
+                    None => VariableId::new(self, x),
                 })
             }
         }
@@ -244,7 +260,7 @@ impl<T: Debugger + 'static> ExpressionContext<T> {
     pub fn strip_symbols_traced(
         &mut self,
         expr: TracedExpr<QualifiedName>,
-    ) -> TracedExpr<usize> {
+    ) -> TracedExpr<VariableId> {
         TracedExpr {
             location: expr.location,
             evaluated: self.strip_symbols(expr.evaluated),
@@ -257,17 +273,13 @@ impl<T: Debugger + 'static> ExpressionContext<T> {
     pub fn strip_symbols_statement(
         &mut self,
         statement: Statement<QualifiedName>,
-    ) -> Statement<usize> {
+    ) -> Statement<VariableId> {
         Statement {
             location: statement.location,
             var: statement.var.map(|var| {
                 match self.symbol_table.get_by_right(&var) {
                     Some(id) => *id,
-                    None => {
-                        let id = self.symbol_table.len();
-                        self.symbol_table.insert(id, var);
-                        id
-                    }
+                    None => VariableId::new(self, var),
                 }
             }),
             type_annotation: statement.type_annotation,
@@ -278,7 +290,7 @@ impl<T: Debugger + 'static> ExpressionContext<T> {
     pub fn strip_symbols_raw(
         &mut self,
         expr: RawExpr<QualifiedName>,
-    ) -> RawExpr<usize> {
+    ) -> RawExpr<VariableId> {
         RawExpr {
             location: expr.location,
             expr: match expr.expr {
@@ -309,11 +321,7 @@ impl<T: Debugger + 'static> ExpressionContext<T> {
                         .into_iter()
                         .map(|var| match self.symbol_table.get_by_right(&var) {
                             Some(id) => *id,
-                            None => {
-                                let id = self.symbol_table.len();
-                                self.symbol_table.insert(id, var);
-                                id
-                            }
+                            None => VariableId::new(self, var),
                         })
                         .collect();
 
@@ -337,11 +345,7 @@ impl<T: Debugger + 'static> ExpressionContext<T> {
                 RawExprRec::Var(x) => {
                     RawExprRec::Var(match self.symbol_table.get_by_right(&x) {
                         Some(id) => *id,
-                        None => {
-                            let id = self.symbol_table.len();
-                            self.symbol_table.insert(id, x);
-                            id
-                        }
+                        None => VariableId::new(self, x),
                     })
                 }
             },
@@ -352,7 +356,7 @@ impl<T: Debugger + 'static> ExpressionContext<T> {
     /// in the symbol table.
     pub fn restore_symbols(
         &self,
-        expr: TracedExprRec<usize>,
+        expr: TracedExprRec<VariableId>,
     ) -> TracedExprRec<QualifiedName> {
         match expr {
             TracedExprRec::None => TracedExprRec::None,
@@ -425,7 +429,7 @@ impl<T: Debugger + 'static> ExpressionContext<T> {
     /// in the symbol table.
     pub fn restore_symbols_traced(
         &self,
-        expr: TracedExpr<usize>,
+        expr: TracedExpr<VariableId>,
     ) -> TracedExpr<QualifiedName> {
         TracedExpr {
             location: expr.location,
@@ -438,7 +442,7 @@ impl<T: Debugger + 'static> ExpressionContext<T> {
     /// in the symbol table.
     pub fn restore_symbols_statement(
         &self,
-        statement: Statement<usize>,
+        statement: Statement<VariableId>,
     ) -> Statement<QualifiedName> {
         Statement {
             location: statement.location,
@@ -460,7 +464,7 @@ impl<T: Debugger + 'static> ExpressionContext<T> {
     /// in the symbol table.
     pub fn restore_symbols_raw(
         &self,
-        expr: RawExpr<usize>,
+        expr: RawExpr<VariableId>,
     ) -> RawExpr<QualifiedName> {
         RawExpr {
             location: expr.location,
@@ -559,9 +563,9 @@ mod tests_for_symbols {
 /// Apply an expression to a list of arguments in a traced manner.
 pub fn apply_traced<T: Debugger + 'static>(
     ctx: &Context<T>,
-    expr: TracedExpr<usize>,
-    args: &[TracedExpr<usize>],
-) -> Result<TracedExpr<usize>, EvaluationError> {
+    expr: TracedExpr<VariableId>,
+    args: &[TracedExpr<VariableId>],
+) -> Result<TracedExpr<VariableId>, EvaluationError> {
     let evaluated = evaluate::<T>(
         ctx,
         TracedExprRec::Apply(
@@ -571,7 +575,7 @@ pub fn apply_traced<T: Debugger + 'static>(
     );
 
     // Before building the trace, expand variables in args
-    let expanded_args: Vec<TracedExpr<usize>> = args
+    let expanded_args: Vec<TracedExpr<VariableId>> = args
         .iter()
         .map(|arg| match &arg.evaluated {
             TracedExprRec::Var(var_name) => {
@@ -601,8 +605,8 @@ pub fn apply_traced<T: Debugger + 'static>(
 
 pub fn evaluate_traced<T: Debugger + 'static>(
     ctx: &Context<T>,
-    expr: TracedExpr<usize>,
-) -> Result<TracedExpr<usize>, EvaluationError> {
+    expr: TracedExpr<VariableId>,
+) -> Result<TracedExpr<VariableId>, EvaluationError> {
     evaluate_traced_rec::<T>(ctx, expr.evaluated.clone())
 }
 
@@ -632,15 +636,15 @@ mod tests {
 
 pub fn evaluate<T: Debugger + 'static>(
     ctx: &Context<T>,
-    expr: TracedExprRec<usize>,
-) -> Result<TracedExpr<usize>, EvaluationError> {
+    expr: TracedExprRec<VariableId>,
+) -> Result<TracedExpr<VariableId>, EvaluationError> {
     evaluate_traced_rec::<T>(ctx, expr)
 }
 
 fn evaluate_traced_rec<T: Debugger + 'static>(
     ctx: &Context<T>,
-    expr: TracedExprRec<usize>,
-) -> Result<TracedExpr<usize>, EvaluationError> {
+    expr: TracedExprRec<VariableId>,
+) -> Result<TracedExpr<VariableId>, EvaluationError> {
     match expr {
         // Literals evaluate to themselves.
         TracedExprRec::None => Ok(expr.traced()),
@@ -688,7 +692,7 @@ fn evaluate_traced_rec<T: Debugger + 'static>(
 ///  and executes them.
 pub fn interpret<T>(
     ctx: &Context<T>,
-    statements: &[Statement<usize>],
+    statements: &[Statement<VariableId>],
 ) -> Result<(), EvaluationError>
 where
     T: Debugger + 'static,
@@ -711,11 +715,11 @@ where
 
 pub fn evaluate_function_application<T: Debugger + 'static>(
     ctx: &Context<T>,
-    action_expr: &TracedExprRec<usize>,
-) -> Result<TracedExpr<usize>, EvaluationError> {
+    action_expr: &TracedExprRec<VariableId>,
+) -> Result<TracedExpr<VariableId>, EvaluationError> {
     match &action_expr {
         TracedExprRec::Apply(action, args) => {
-            let evaluated_args: Result<Vec<TracedExpr<usize>>, _> = args
+            let evaluated_args: Result<Vec<TracedExpr<VariableId>>, _> = args
                 .into_iter()
                 .map(|arg| evaluate_traced::<T>(ctx, arg.clone()))
                 .collect();
@@ -726,7 +730,7 @@ pub fn evaluate_function_application<T: Debugger + 'static>(
                 .evaluated
                 .clone();
 
-            let expanded_args: Vec<TracedExpr<usize>> = args
+            let expanded_args: Vec<TracedExpr<VariableId>> = args
                 .into_iter()
                 .map(|arg| {
                     if let TracedExprRec::Var(var_name) = &arg.evaluated {
@@ -773,14 +777,14 @@ pub fn evaluate_function_application<T: Debugger + 'static>(
 
 fn function_from_expression<T: Debugger + 'static>(
     ctx: &Context<T>,
-    evaluated_args: &Vec<TracedExpr<usize>>,
-    resolved: TracedExprRec<usize>,
+    evaluated_args: &Vec<TracedExpr<VariableId>>,
+    resolved: TracedExprRec<VariableId>,
 ) -> Result<
     Box<
         dyn Fn(
             &Context<T>,
-            &[TracedExpr<usize>],
-        ) -> Result<TracedExprRec<usize>, EvaluationError>,
+            &[TracedExpr<VariableId>],
+        ) -> Result<TracedExprRec<VariableId>, EvaluationError>,
     >,
     EvaluationError,
 > {
@@ -807,10 +811,7 @@ fn function_from_expression<T: Debugger + 'static>(
             let arg_types: Vec<_> = evaluated_args
                 .iter()
                 .map(|arg| {
-                    type_of::<_, _, RuntimeLookup>(
-                        &ctx.expression_context.read(),
-                        &arg.evaluated,
-                    )
+                    type_of(&ctx.expression_context.read(), &arg.evaluated)
                 })
                 .collect();
 
@@ -881,7 +882,7 @@ fn function_from_expression<T: Debugger + 'static>(
             let vars = vars.clone();
             let statements = statements.clone();
             let result = result.clone();
-            Box::new(move |ctx, var_values: &[TracedExpr<usize>]| {
+            Box::new(move |ctx, var_values: &[TracedExpr<VariableId>]| {
                 if vars.len() != var_values.len() {
                     return Err(EvaluationError::WrongNumberOfArguments {
                         expected: vars.len(),
@@ -891,32 +892,35 @@ fn function_from_expression<T: Debugger + 'static>(
                 }
 
                 // Substitute variables in statements with their corresponding values
-                let substituted_statements: Vec<Statement<usize>> = statements
-                    .iter()
-                    .map(|statement| {
-                        let substituted_expr =
-                            vars.iter().zip(var_values.iter()).fold(
-                                statement.expr.clone(),
-                                |acc, (var, var_value)| {
-                                    substitute(
-                                        var,
-                                        &var_value
-                                            .evaluated
-                                            .clone()
-                                            .untraced()
-                                            .as_expr(),
-                                        acc,
-                                    )
-                                },
-                            );
-                        Statement {
-                            location: statement.location,
-                            var: statement.var.clone(),
-                            type_annotation: statement.type_annotation.clone(),
-                            expr: substituted_expr,
-                        }
-                    })
-                    .collect();
+                let substituted_statements: Vec<Statement<VariableId>> =
+                    statements
+                        .iter()
+                        .map(|statement| {
+                            let substituted_expr =
+                                vars.iter().zip(var_values.iter()).fold(
+                                    statement.expr.clone(),
+                                    |acc, (var, var_value)| {
+                                        substitute(
+                                            var,
+                                            &var_value
+                                                .evaluated
+                                                .clone()
+                                                .untraced()
+                                                .as_expr(),
+                                            acc,
+                                        )
+                                    },
+                                );
+                            Statement {
+                                location: statement.location,
+                                var: statement.var.clone(),
+                                type_annotation: statement
+                                    .type_annotation
+                                    .clone(),
+                                expr: substituted_expr,
+                            }
+                        })
+                        .collect();
 
                 // Run the substituted statements
                 interpret::<T>(ctx, &substituted_statements)?;
@@ -931,7 +935,7 @@ fn function_from_expression<T: Debugger + 'static>(
                     .from_raw();
 
                 // Run the result to get the return value
-                let result: Result<TracedExprRec<usize>, EvaluationError> =
+                let result: Result<TracedExprRec<VariableId>, EvaluationError> =
                     evaluate_traced::<T>(ctx, substituted_result_expr)
                         .map(|x| x.evaluated);
 

--- a/src/lsp/autocomplete.rs
+++ b/src/lsp/autocomplete.rs
@@ -1,10 +1,8 @@
 use rayon::prelude::*;
 
 use crate::{
-    debugging::Debugger,
-    interpreter::Context,
-    parser::parse,
-    typechecking::{type_of, NoLookup},
+    debugging::Debugger, interpreter::Context, parser::parse,
+    typechecking::type_of,
 };
 
 ///
@@ -27,8 +25,15 @@ pub fn autocomplete<'a, T: Debugger + 'static>(
         return vec![];
     }
 
-    let expr = statements[0].expr.clone();
-    let expr_type = type_of::<_, _, NoLookup>(
+    let statement = statements[0].clone();
+
+    let expr = context
+        .expression_context
+        .write()
+        .strip_symbols_statement(statement)
+        .expr;
+
+    let expr_type = type_of(
         &context.expression_context.read(),
         &expr.from_raw().evaluated,
     );

--- a/src/lsp/autocomplete.rs
+++ b/src/lsp/autocomplete.rs
@@ -2,7 +2,10 @@ use rayon::prelude::*;
 use tower_lsp::lsp_types::Position;
 
 use crate::{
-    ast::{raw_expr::RawExpr, Statement},
+    ast::{
+        raw_expr::{RawExpr, RawExprRec},
+        Statement,
+    },
     debugging::Debugger,
     interpreter::{Context, VariableId},
     parser::{parse, CodeLocation},
@@ -18,9 +21,55 @@ pub fn autocomplete_at<'a, T: Debugger + 'static>(
     statements: &Vec<Statement<VariableId>>,
     cursor: Position,
 ) -> Vec<String> {
-    // TODO: Traverse through the statements until arriving at the correct line,
-    // then traverse through the statement to try to find the correct column.
-    // In the future we may want to build an index to speed this process up.
+    // Note: In the future we may want to build an index to speed this process up.
+
+    // Do a binary search to try to find a matching line.
+    let search_result = statements
+        .binary_search_by(|x| x.location.unwrap().line.cmp(&cursor.line));
+
+    match search_result {
+        Ok(i) => {
+            // If we found a matching line, we can just search the matching
+            // statement.
+            let found_line = &statements[i];
+
+            let found_expr = find_expr_before(cursor, &found_line.expr);
+
+            autocomplete(context, &found_expr)
+        }
+        Err(i) => {
+            // Otherwise, we need to look at the line before where the
+            //  match would have been inserted.
+
+            let search_line = &statements[i - 1];
+
+            // This should be a lambda that we can look into to find the actual line.
+            match &search_line.expr.expr {
+                RawExprRec::Lambda(_, lambda_statements, _) => {
+                    autocomplete_at(context, &lambda_statements, cursor)
+                }
+                _ => panic!("Internal error: Autocompletion expected a lambda"),
+            }
+        }
+    }
+}
+
+///
+/// Traverses through an expression to find the expression immediately before the
+///  cursor's location on the current line.
+///
+/// For example, if there was an expression at (2:31), and another at (2:33)
+///  and the cursor was at (2:32), we'd return the expression at (2:31).
+///
+/// Note: Currently our line / column numbering data does not include the entire
+///  "length" of the tokens, which makes it difficult to tell if the cursor
+///  is actually "after" an expression. This will have to be fixed somehow
+///  in the future.
+///
+fn find_expr_before(
+    cursor: Position,
+    expr: &RawExpr<VariableId>,
+) -> RawExpr<VariableId> {
     todo!()
 }
 

--- a/src/lsp/autocomplete.rs
+++ b/src/lsp/autocomplete.rs
@@ -1,8 +1,10 @@
 use rayon::prelude::*;
 
 use crate::{
-    debugging::Debugger, interpreter::Context, parser::parse,
-    typechecking::type_of,
+    debugging::Debugger,
+    interpreter::Context,
+    parser::parse,
+    typechecking::{type_of, TypingContext},
 };
 
 ///
@@ -35,10 +37,11 @@ pub fn autocomplete<'a, T: Debugger + 'static>(
 
     let expr_type = type_of(
         &context.expression_context.read(),
+        &TypingContext::new(),
         &expr.from_raw().evaluated,
     );
 
-    if expr_type.is_none() {
+    if expr_type.is_err() {
         return vec![];
     }
 

--- a/src/lsp/autocomplete.rs
+++ b/src/lsp/autocomplete.rs
@@ -22,7 +22,7 @@ pub fn autocomplete<'a, T: Debugger + 'static>(
         return vec![];
     }
 
-    let (imports, statements) = parsed.unwrap();
+    let (_imports, statements) = parsed.unwrap();
     if statements.len() != 1 {
         return vec![];
     }
@@ -53,6 +53,7 @@ pub fn autocomplete<'a, T: Debugger + 'static>(
         .functions
         // In most applications there will be a large amount of functions
         //  to sift through, so parallelize.
+        .raw
         .par_iter()
         .filter(|f| {
             if f.1.argument_types.is_empty() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use color_eyre::eyre::eyre;
 use ef3r::ast::raw_expr::{RawExpr, RawExprRec};
 use ef3r::debugging::{GrpcDebugger, NoOpDebugger, StepDebugger};
 use ef3r::executable::{load_efrs_file, load_efrs_or_ef3r, Executable};
-use ef3r::interpreter::{self};
+use ef3r::interpreter::{self, VariableId};
 use ef3r::node_visualization::node_visualizer_server::NodeVisualizerServer;
 use ef3r::node_visualization::{node_visualization, NodeVisualizerState};
 use ef3r::typechecking;
@@ -106,7 +106,11 @@ async fn main() -> color_eyre::eyre::Result<()> {
             if result.is_empty() {
                 println!("Successfully typechecked program");
             } else {
-                println!("Found errors while typechecking program.");
+                println!("Found errors while typechecking program:");
+
+                for error in result {
+                    println!("{:?}", error)
+                }
             }
         }
         Commands::Execute { file } => {
@@ -227,8 +231,8 @@ fn start_visualizer(state: NodeVisualizerState) {
 /// Strips line numbers and type annotations from statements.
 ///
 fn strip_statement_metadata(
-    statement: ef3r::ast::Statement<usize>,
-) -> ef3r::ast::Statement<usize> {
+    statement: ef3r::ast::Statement<VariableId>,
+) -> ef3r::ast::Statement<VariableId> {
     ef3r::ast::Statement {
         location: None,
         var: statement.var,
@@ -237,7 +241,9 @@ fn strip_statement_metadata(
     }
 }
 
-fn strip_line_numbers_raw_expr(expr: RawExpr<usize>) -> RawExpr<usize> {
+fn strip_line_numbers_raw_expr(
+    expr: RawExpr<VariableId>,
+) -> RawExpr<VariableId> {
     RawExpr {
         location: expr.location,
         expr: match expr.expr {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use ef3r::executable::{load_efrs_file, load_efrs_or_ef3r, Executable};
 use ef3r::interpreter::{self, VariableId};
 use ef3r::node_visualization::node_visualizer_server::NodeVisualizerServer;
 use ef3r::node_visualization::{node_visualization, NodeVisualizerState};
-use ef3r::typechecking;
+use ef3r::typechecking::{self, TypingContext};
 use parking_lot::RwLock;
 use std::sync::Arc;
 use std::{fs::File, io::Write};
@@ -100,6 +100,7 @@ async fn main() -> color_eyre::eyre::Result<()> {
 
             let result = typechecking::typecheck(
                 &context.expression_context.read(),
+                &mut TypingContext::new(),
                 program,
             );
 

--- a/src/modules.rs
+++ b/src/modules.rs
@@ -17,8 +17,10 @@ use std::{
 use quickcheck::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
+use typed_index_collections::TiVec;
 
 use crate::{
+    ast::expr::FunctionID,
     debugging::Debugger,
     interpreter::{Context, FunctionDefinition, PolymorphicIndex},
 };
@@ -94,15 +96,15 @@ impl<const N: usize, T: Debugger> Module<N, T> {
 }
 
 fn build_polymorphic_index<T: Debugger + 'static>(
-    functions: &[(ModuleName, FunctionDefinition<T>)],
-) -> Result<HashMap<PolymorphicIndex, usize>, String> {
+    functions: &TiVec<FunctionID, (ModuleName, FunctionDefinition<T>)>,
+) -> Result<HashMap<PolymorphicIndex, FunctionID>, String> {
     // Needs to be stable, otherwise the IDs will be nondeterministic.
     let mut name_buckets: BTreeMap<
         String,
-        Vec<(usize, &FunctionDefinition<T>)>,
+        Vec<(FunctionID, &FunctionDefinition<T>)>,
     > = BTreeMap::new();
 
-    for id in 0..functions.len() - 1 {
+    for id in functions.keys() {
         let func = &functions[id];
         name_buckets
             .entry(func.1.name.clone())

--- a/src/modules/base.rs
+++ b/src/modules/base.rs
@@ -1,5 +1,7 @@
+use std::env::Vars;
+
 use crate::ast::raw_expr::{substitute_statement, substitute_traced};
-use crate::typechecking::RuntimeLookup;
+use crate::interpreter::VariableId;
 use crate::{
     ast::traced_expr::{TracedExpr, TracedExprRec},
     debugging::Debugger,
@@ -34,7 +36,7 @@ pub fn base_module<T: Debugger>() -> Module<10, T> {
                                 Box::new(ExprType::Any),
                                 Box::new(ExprType::Any),
                             ),
-                            actual: type_of::<_, _, RuntimeLookup>(
+                            actual: type_of(
                                 &ctx.expression_context.read(),
                                 &actual,
                             )
@@ -60,7 +62,7 @@ pub fn base_module<T: Debugger>() -> Module<10, T> {
                                 Box::new(ExprType::Any),
                                 Box::new(ExprType::Any),
                             ),
-                            actual: type_of::<_, _, RuntimeLookup>(
+                            actual: type_of(
                                 &ctx.expression_context.read(),
                                 &actual,
                             )
@@ -108,7 +110,7 @@ pub fn base_module<T: Debugger>() -> Module<10, T> {
                 vec![ExprType::Any],
                 |ctx, first| {
                     Ok(
-                        match type_of::<_, _, RuntimeLookup>(
+                        match type_of(
                             &ctx.expression_context.read(),
                             &first.evaluated,
                         ) {
@@ -122,7 +124,7 @@ pub fn base_module<T: Debugger>() -> Module<10, T> {
                 name: "assert".to_string(),
                 argument_types: vec![ExprType::Bool],
                 result_type: ExprType::Unit,
-                definition: |ctx, args: &[TracedExpr<usize>]| {
+                definition: |ctx, args: &[TracedExpr<VariableId>]| {
                     let condition = match args[0].evaluated {
                         TracedExprRec::Bool(b) => b,
                         _ => unreachable!(),
@@ -196,8 +198,8 @@ pub fn base_module<T: Debugger>() -> Module<10, T> {
 }
 
 fn partial_application<T: Debugger>(
-    args: &[TracedExpr<usize>],
-) -> Result<TracedExprRec<usize>, EvaluationError> {
+    args: &[TracedExpr<VariableId>],
+) -> Result<TracedExprRec<VariableId>, EvaluationError> {
     let function = ensure_eta_expanded(args[0].clone());
 
     let args_to_apply = &args[1..];
@@ -214,7 +216,7 @@ fn partial_application<T: Debugger>(
                 .into_iter()
                 .skip(args_to_apply.len())
                 .map(|x| *x)
-                .collect::<Vec<usize>>();
+                .collect::<Vec<VariableId>>();
 
             let new_body = Box::new(
                 subst.clone().fold(*body.to_owned(), |expr, (var, with)| {
@@ -241,7 +243,7 @@ fn partial_application<T: Debugger>(
 ///
 /// Ensures that a function expression is eta-expanded.
 ///
-fn ensure_eta_expanded(expr: TracedExpr<usize>) -> TracedExpr<usize> {
+fn ensure_eta_expanded(expr: TracedExpr<VariableId>) -> TracedExpr<VariableId> {
     match &expr.evaluated {
         TracedExprRec::Lambda(_, _, _) => expr,
         TracedExprRec::Apply(_f, _x) => todo!(),

--- a/src/modules/base.rs
+++ b/src/modules/base.rs
@@ -1,5 +1,3 @@
-use std::env::Vars;
-
 use crate::ast::raw_expr::{substitute_statement, substitute_traced};
 use crate::interpreter::VariableId;
 use crate::typechecking::TypingContext;

--- a/src/modules/base.rs
+++ b/src/modules/base.rs
@@ -2,6 +2,7 @@ use std::env::Vars;
 
 use crate::ast::raw_expr::{substitute_statement, substitute_traced};
 use crate::interpreter::VariableId;
+use crate::typechecking::TypingContext;
 use crate::{
     ast::traced_expr::{TracedExpr, TracedExprRec},
     debugging::Debugger,
@@ -38,6 +39,7 @@ pub fn base_module<T: Debugger>() -> Module<10, T> {
                             ),
                             actual: type_of(
                                 &ctx.expression_context.read(),
+                                &TypingContext::new(),
                                 &actual,
                             )
                             .unwrap(),
@@ -64,6 +66,7 @@ pub fn base_module<T: Debugger>() -> Module<10, T> {
                             ),
                             actual: type_of(
                                 &ctx.expression_context.read(),
+                                &TypingContext::new(),
                                 &actual,
                             )
                             .unwrap(),
@@ -112,10 +115,11 @@ pub fn base_module<T: Debugger>() -> Module<10, T> {
                     Ok(
                         match type_of(
                             &ctx.expression_context.read(),
+                            &TypingContext::new(),
                             &first.evaluated,
                         ) {
-                            Some(x) => TracedExprRec::Type(x),
-                            None => TracedExprRec::None,
+                            Ok(x) => TracedExprRec::Type(x),
+                            Err(_errs) => TracedExprRec::None,
                         },
                     )
                 }

--- a/src/modules/bool.rs
+++ b/src/modules/bool.rs
@@ -1,9 +1,8 @@
-use crate::typechecking::RuntimeLookup;
 use crate::{
     ast::traced_expr::{TracedExpr, TracedExprRec},
     debugging::Debugger,
     extern_utils::*,
-    interpreter::{EvaluationError, FunctionDefinition},
+    interpreter::{EvaluationError, FunctionDefinition, VariableId},
     typechecking::type_of,
     types::ExprType,
 };
@@ -18,10 +17,10 @@ pub fn bool_module<T: Debugger>() -> Module<4, T> {
             build_function!(T, "==", ExprType::Bool, |_cx,
 
                                                       x: TracedExprRec<
-                usize,
+                VariableId,
             >,
                                                       y: TracedExprRec<
-                usize,
+                VariableId,
             >| {
                 Ok(x == y)
             }),

--- a/src/modules/bool.rs
+++ b/src/modules/bool.rs
@@ -4,6 +4,7 @@ use crate::{
     extern_utils::*,
     interpreter::{EvaluationError, FunctionDefinition, VariableId},
     typechecking::type_of,
+    typechecking::TypingContext,
     types::ExprType,
 };
 

--- a/src/modules/io.rs
+++ b/src/modules/io.rs
@@ -4,7 +4,7 @@ use crate::{
     ast::traced_expr::{TracedExpr, TracedExprRec},
     debugging::Debugger,
     extern_utils::*,
-    interpreter::{EvaluationError, FunctionDefinition},
+    interpreter::{EvaluationError, FunctionDefinition, VariableId},
     types::ExprType,
 };
 
@@ -43,7 +43,7 @@ pub fn io_module<T: Debugger>() -> Module<2, T> {
                 name: "readln".to_string(),
                 argument_types: vec![],
                 result_type: ExprType::String,
-                definition: |_, _: &[TracedExpr<usize>]| {
+                definition: |_, _: &[TracedExpr<VariableId>]| {
                     let stdin = io::stdin();
                     let result = stdin.lock().lines().next().unwrap().unwrap();
 

--- a/src/modules/io.rs
+++ b/src/modules/io.rs
@@ -5,7 +5,6 @@ use crate::{
     debugging::Debugger,
     extern_utils::*,
     interpreter::{EvaluationError, FunctionDefinition, VariableId},
-    typechecking::TypingContext,
     types::ExprType,
 };
 

--- a/src/modules/io.rs
+++ b/src/modules/io.rs
@@ -5,6 +5,7 @@ use crate::{
     debugging::Debugger,
     extern_utils::*,
     interpreter::{EvaluationError, FunctionDefinition, VariableId},
+    typechecking::TypingContext,
     types::ExprType,
 };
 

--- a/src/modules/lists.rs
+++ b/src/modules/lists.rs
@@ -1,10 +1,10 @@
-use crate::typechecking::RuntimeLookup;
 use crate::{
     ast::traced_expr::{TracedExpr, TracedExprRec},
     debugging::Debugger,
     extern_utils::*,
     interpreter::{
         evaluate_function_application, EvaluationError, FunctionDefinition,
+        VariableId,
     },
     typechecking::type_of,
     types::ExprType,
@@ -21,7 +21,7 @@ pub fn lists_module<T: Debugger>() -> Module<11, T> {
                 T,
                 "drop",
                 ExprType::List(Box::new(ExprType::Any)),
-                |_cx, list: Vec<TracedExpr<usize>>, n: i32| {
+                |_cx, list: Vec<TracedExpr<VariableId>>, n: i32| {
                     Ok(if n <= 0 {
                         list
                     } else {
@@ -33,7 +33,7 @@ pub fn lists_module<T: Debugger>() -> Module<11, T> {
                 T,
                 "drop_last",
                 ExprType::List(Box::new(ExprType::Any)),
-                |_cx, list: Vec<TracedExpr<usize>>, n: i32| {
+                |_cx, list: Vec<TracedExpr<VariableId>>, n: i32| {
                     Ok(if n <= 0 {
                         list
                     } else {
@@ -50,8 +50,8 @@ pub fn lists_module<T: Debugger>() -> Module<11, T> {
                 ExprType::List(Box::new(ExprType::Any)),
                 |_cx,
 
-                 list1: Vec<TracedExpr<usize>>,
-                 list2: Vec<TracedExpr<usize>>| {
+                 list1: Vec<TracedExpr<VariableId>>,
+                 list2: Vec<TracedExpr<VariableId>>| {
                     let mut result = list1;
                     result.extend(list2);
                     Ok(result)
@@ -165,7 +165,7 @@ pub fn lists_module<T: Debugger>() -> Module<11, T> {
             build_function!(T, "first", ExprType::Any, |_cx,
 
                                                         list: Vec<
-                TracedExpr<usize>,
+                TracedExpr<VariableId>,
             >| {
                 Ok(list
                     .first()
@@ -175,7 +175,7 @@ pub fn lists_module<T: Debugger>() -> Module<11, T> {
             build_function!(T, "last", ExprType::Any, |_cx,
 
                                                        list: Vec<
-                TracedExpr<usize>,
+                TracedExpr<VariableId>,
             >| {
                 Ok(list
                     .last()
@@ -186,7 +186,7 @@ pub fn lists_module<T: Debugger>() -> Module<11, T> {
                 name: "list".to_string(),
                 argument_types: vec![], // Vararg function
                 result_type: ExprType::List(Box::new(ExprType::Any)),
-                definition: |_, xs: &[TracedExpr<usize>]| {
+                definition: |_, xs: &[TracedExpr<VariableId>]| {
                     Ok(TracedExprRec::List(xs.to_vec()))
                 },
             },
@@ -213,8 +213,8 @@ pub fn lists_module<T: Debugger>() -> Module<11, T> {
                 "intersperse",
                 ExprType::List(Box::new(ExprType::Any)),
                 |_cx,
-                 list: Vec<TracedExpr<usize>>,
-                 separator: TracedExprRec<usize>| {
+                 list: Vec<TracedExpr<VariableId>>,
+                 separator: TracedExprRec<VariableId>| {
                     if list.is_empty() {
                         return Ok(TracedExprRec::List(list));
                     }

--- a/src/modules/lists.rs
+++ b/src/modules/lists.rs
@@ -7,6 +7,7 @@ use crate::{
         VariableId,
     },
     typechecking::type_of,
+    typechecking::TypingContext,
     types::ExprType,
 };
 

--- a/src/modules/math.rs
+++ b/src/modules/math.rs
@@ -1,9 +1,8 @@
-use crate::typechecking::RuntimeLookup;
 use crate::{
     ast::traced_expr::{TracedExpr, TracedExprRec},
     debugging::Debugger,
     extern_utils::*,
-    interpreter::{EvaluationError, FunctionDefinition},
+    interpreter::{EvaluationError, FunctionDefinition, VariableId},
     typechecking::type_of,
     types::ExprType,
 };
@@ -25,7 +24,7 @@ pub fn math_module<T: Debugger>() -> Module<19, T> {
                 name: "/".to_string(),
                 argument_types: vec![ExprType::Int, ExprType::Int],
                 result_type: ExprType::Int,
-                definition: |ctx, args: &[TracedExpr<usize>]| {
+                definition: |ctx, args: &[TracedExpr<VariableId>]| {
                     let x = match args[0].evaluated {
                         TracedExprRec::Int(i) => i,
                         _ => unreachable!(),
@@ -67,7 +66,7 @@ pub fn math_module<T: Debugger>() -> Module<19, T> {
                 name: "/".to_string(),
                 argument_types: vec![ExprType::Float, ExprType::Float],
                 result_type: ExprType::Float,
-                definition: |ctx, args: &[TracedExpr<usize>]| {
+                definition: |ctx, args: &[TracedExpr<VariableId>]| {
                     let x = match args[0].evaluated {
                         TracedExprRec::Float(i) => i,
                         _ => unreachable!(),
@@ -157,7 +156,7 @@ pub fn math_module<T: Debugger>() -> Module<19, T> {
                 name: "asin".to_string(),
                 argument_types: vec![ExprType::Float],
                 result_type: ExprType::Float,
-                definition: |ctx, args: &[TracedExpr<usize>]| {
+                definition: |ctx, args: &[TracedExpr<VariableId>]| {
                     let x = match args[0].evaluated {
                         TracedExprRec::Float(i) => i,
                         _ => unreachable!(),
@@ -185,7 +184,7 @@ pub fn math_module<T: Debugger>() -> Module<19, T> {
                 name: "acos".to_string(),
                 argument_types: vec![ExprType::Float],
                 result_type: ExprType::Float,
-                definition: |ctx, args: &[TracedExpr<usize>]| {
+                definition: |ctx, args: &[TracedExpr<VariableId>]| {
                     let x = match args[0].evaluated {
                         TracedExprRec::Float(i) => i,
                         _ => unreachable!(),
@@ -213,7 +212,7 @@ pub fn math_module<T: Debugger>() -> Module<19, T> {
                 name: "tan".to_string(),
                 argument_types: vec![ExprType::Float],
                 result_type: ExprType::Float,
-                definition: |ctx, args: &[TracedExpr<usize>]| {
+                definition: |ctx, args: &[TracedExpr<VariableId>]| {
                     let x = match args[0].evaluated {
                         TracedExprRec::Float(i) => i,
                         _ => unreachable!(),
@@ -241,7 +240,7 @@ pub fn math_module<T: Debugger>() -> Module<19, T> {
                 name: "cot".to_string(),
                 argument_types: vec![ExprType::Float],
                 result_type: ExprType::Float,
-                definition: |ctx, args: &[TracedExpr<usize>]| {
+                definition: |ctx, args: &[TracedExpr<VariableId>]| {
                     let x = match args[0].evaluated {
                         TracedExprRec::Float(i) => i,
                         _ => unreachable!(),
@@ -269,7 +268,7 @@ pub fn math_module<T: Debugger>() -> Module<19, T> {
                 name: "tanh".to_string(),
                 argument_types: vec![ExprType::Float],
                 result_type: ExprType::Float,
-                definition: |_ctx, args: &[TracedExpr<usize>]| {
+                definition: |_ctx, args: &[TracedExpr<VariableId>]| {
                     let x = match args[0].evaluated {
                         TracedExprRec::Float(i) => i,
                         _ => unreachable!(),
@@ -282,7 +281,7 @@ pub fn math_module<T: Debugger>() -> Module<19, T> {
                 name: "cosh".to_string(),
                 argument_types: vec![ExprType::Float],
                 result_type: ExprType::Float,
-                definition: |_ctx, args: &[TracedExpr<usize>]| {
+                definition: |_ctx, args: &[TracedExpr<VariableId>]| {
                     let x = match args[0].evaluated {
                         TracedExprRec::Float(i) => i,
                         _ => unreachable!(),
@@ -295,7 +294,7 @@ pub fn math_module<T: Debugger>() -> Module<19, T> {
                 name: "acosh".to_string(),
                 argument_types: vec![ExprType::Float],
                 result_type: ExprType::Float,
-                definition: |ctx, args: &[TracedExpr<usize>]| {
+                definition: |ctx, args: &[TracedExpr<VariableId>]| {
                     let x = match args[0].evaluated {
                         TracedExprRec::Float(i) => i,
                         _ => unreachable!(),
@@ -322,7 +321,7 @@ pub fn math_module<T: Debugger>() -> Module<19, T> {
                 name: "atanh".to_string(),
                 argument_types: vec![ExprType::Float],
                 result_type: ExprType::Float,
-                definition: |ctx, args: &[TracedExpr<usize>]| {
+                definition: |ctx, args: &[TracedExpr<VariableId>]| {
                     let x = match args[0].evaluated {
                         TracedExprRec::Float(i) => i,
                         _ => unreachable!(),
@@ -349,7 +348,7 @@ pub fn math_module<T: Debugger>() -> Module<19, T> {
                 name: "pow".to_string(),
                 argument_types: vec![ExprType::Float, ExprType::Float],
                 result_type: ExprType::Float,
-                definition: |ctx, args: &[TracedExpr<usize>]| {
+                definition: |ctx, args: &[TracedExpr<VariableId>]| {
                     let base = match args[0].evaluated {
                         TracedExprRec::Float(i) => i,
                         _ => unreachable!(),

--- a/src/modules/math.rs
+++ b/src/modules/math.rs
@@ -4,6 +4,7 @@ use crate::{
     extern_utils::*,
     interpreter::{EvaluationError, FunctionDefinition, VariableId},
     typechecking::type_of,
+    typechecking::TypingContext,
     types::ExprType,
 };
 

--- a/src/modules/reactive.rs
+++ b/src/modules/reactive.rs
@@ -11,9 +11,9 @@ use crate::{
     frp::{filter_node, fold_node, map_node, Node},
     interpreter::{
         evaluate_function_application, Context, EvaluationError,
-        FunctionDefinition,
+        FunctionDefinition, VariableId,
     },
-    typechecking::{type_of, RuntimeLookup},
+    typechecking::type_of,
     types::ExprType,
 };
 
@@ -32,7 +32,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                 |ctx, first, second| {
                     match first.evaluated {
                         TracedExprRec::Type(x) => {
-                            if type_of::<_, _, RuntimeLookup>(
+                            if type_of(
                                 &ctx.expression_context.read(),
                                 &second.evaluated,
                             ) == Some(x.clone())
@@ -56,7 +56,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                             } else {
                                 Err(EvaluationError::TypeError {
                                     expected: x,
-                                    actual: type_of::<_, _, RuntimeLookup>(
+                                    actual: type_of(
                                         &ctx.expression_context.read(),
                                         &second.evaluated,
                                     )
@@ -67,7 +67,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                         }
                         actual => Err(EvaluationError::TypeError {
                             expected: ExprType::Type,
-                            actual: type_of::<_, _, RuntimeLookup>(
+                            actual: type_of(
                                 &ctx.expression_context.read(),
                                 &actual,
                             )
@@ -91,7 +91,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                         }
                         actual => Err(EvaluationError::TypeError {
                             expected: ExprType::Node(Box::new(ExprType::Any)),
-                            actual: type_of::<_, _, RuntimeLookup>(
+                            actual: type_of(
                                 &ctx.expression_context.read(),
                                 &actual,
                             )
@@ -120,7 +120,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                         }
                         actual => Err(EvaluationError::TypeError {
                             expected: ExprType::Node(Box::new(ExprType::Any)),
-                            actual: type_of::<_, _, RuntimeLookup>(
+                            actual: type_of(
                                 &ctx.expression_context.read(),
                                 &actual,
                             )
@@ -148,7 +148,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                         TracedExprRec::Node(node_id) => {
                             let second_clone = second.clone();
                             let transform = Arc::new(Mutex::new(
-                                move |ctx: &Context<T>, expr: TracedExpr<usize>| {
+                                move |ctx: &Context<T>, expr: TracedExpr<VariableId>| {
                                     evaluate_function_application(
                                         ctx,
                                         &TracedExprRec::Apply(
@@ -181,7 +181,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                         }
                         actual => Err(EvaluationError::TypeError {
                             expected: ExprType::Node(Box::new(ExprType::Any)),
-                            actual: type_of::<_, _, RuntimeLookup>(
+                            actual: type_of(
                                 &ctx.expression_context.read(),
                                 &actual,
                             )
@@ -207,7 +207,10 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                         TracedExprRec::Node(node_id) => {
                             let second_clone = second.clone();
 
-                            let transform = move |ctx: &Context<T>, expr: TracedExpr<usize>| {
+                            let transform = move |ctx: &Context<T>,
+                                                  expr: TracedExpr<
+                                VariableId,
+                            >| {
                                 let result = evaluate_function_application(
                                     ctx,
                                     &TracedExprRec::Apply(
@@ -243,7 +246,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                         }
                         actual => Err(EvaluationError::TypeError {
                             expected: ExprType::Node(Box::new(ExprType::Any)),
-                            actual: type_of::<_, _, RuntimeLookup>(
+                            actual: type_of(
                                 &ctx.expression_context.read(),
                                 &actual,
                             )
@@ -269,7 +272,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                         TracedExprRec::Node(node_id) => {
                             let second_clone = second.clone();
                             let transform = Box::new(
-                                    move |ctx: &Context<T>, expr: TracedExpr<usize>, acc: TracedExpr<usize>| {
+                                    move |ctx: &Context<T>, expr: TracedExpr<VariableId>, acc: TracedExpr<VariableId>| {
                                         evaluate_function_application(
                                             &ctx.clone(),
                                             &TracedExprRec::Apply(
@@ -301,7 +304,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                         }
                         actual => Err(EvaluationError::TypeError {
                             expected: ExprType::Node(Box::new(ExprType::Any)),
-                            actual: type_of::<_, _, RuntimeLookup>(
+                            actual: type_of(
                                 &ctx.expression_context.read(),
                                 &actual,
                             )

--- a/src/modules/reactive.rs
+++ b/src/modules/reactive.rs
@@ -13,7 +13,7 @@ use crate::{
         evaluate_function_application, Context, EvaluationError,
         FunctionDefinition, VariableId,
     },
-    typechecking::type_of,
+    typechecking::{type_of, TypingContext},
     types::ExprType,
 };
 
@@ -34,8 +34,9 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                         TracedExprRec::Type(x) => {
                             if type_of(
                                 &ctx.expression_context.read(),
+                                &TypingContext::new(),
                                 &second.evaluated,
-                            ) == Some(x.clone())
+                            ) == Ok(x.clone())
                             {
                                 let fresh_id = Node::new(
                                     Arc::new(|_, _| {}),
@@ -58,6 +59,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                                     expected: x,
                                     actual: type_of(
                                         &ctx.expression_context.read(),
+                                        &TypingContext::new(),
                                         &second.evaluated,
                                     )
                                     .unwrap(),
@@ -69,6 +71,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                             expected: ExprType::Type,
                             actual: type_of(
                                 &ctx.expression_context.read(),
+                                &TypingContext::new(),
                                 &actual,
                             )
                             .unwrap(),
@@ -93,6 +96,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                             expected: ExprType::Node(Box::new(ExprType::Any)),
                             actual: type_of(
                                 &ctx.expression_context.read(),
+                                &TypingContext::new(),
                                 &actual,
                             )
                             .unwrap(),
@@ -122,6 +126,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                             expected: ExprType::Node(Box::new(ExprType::Any)),
                             actual: type_of(
                                 &ctx.expression_context.read(),
+                                &TypingContext::new(),
                                 &actual,
                             )
                             .unwrap(),
@@ -183,6 +188,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                             expected: ExprType::Node(Box::new(ExprType::Any)),
                             actual: type_of(
                                 &ctx.expression_context.read(),
+                                &TypingContext::new(),
                                 &actual,
                             )
                             .unwrap(),
@@ -248,6 +254,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                             expected: ExprType::Node(Box::new(ExprType::Any)),
                             actual: type_of(
                                 &ctx.expression_context.read(),
+                                &TypingContext::new(),
                                 &actual,
                             )
                             .unwrap(),
@@ -306,6 +313,7 @@ pub fn reactive_module<T: Debugger + Send + Sync>() -> Module<6, T> {
                             expected: ExprType::Node(Box::new(ExprType::Any)),
                             actual: type_of(
                                 &ctx.expression_context.read(),
+                                &TypingContext::new(),
                                 &actual,
                             )
                             .unwrap(),

--- a/src/modules/strings.rs
+++ b/src/modules/strings.rs
@@ -4,6 +4,7 @@ use crate::{
     extern_utils::*,
     interpreter::{EvaluationError, FunctionDefinition, VariableId},
     typechecking::type_of,
+    typechecking::TypingContext,
     types::ExprType,
 };
 

--- a/src/modules/strings.rs
+++ b/src/modules/strings.rs
@@ -1,9 +1,8 @@
-use crate::typechecking::RuntimeLookup;
 use crate::{
     ast::traced_expr::{TracedExpr, TracedExprRec},
     debugging::Debugger,
     extern_utils::*,
-    interpreter::{EvaluationError, FunctionDefinition},
+    interpreter::{EvaluationError, FunctionDefinition, VariableId},
     typechecking::type_of,
     types::ExprType,
 };

--- a/src/modules/threading.rs
+++ b/src/modules/threading.rs
@@ -8,9 +8,9 @@ use crate::{
     extern_utils::*,
     interpreter::{
         evaluate_function_application, Context, EvaluationError,
-        FunctionDefinition,
+        FunctionDefinition, VariableId,
     },
-    typechecking::{type_of, RuntimeLookup},
+    typechecking::type_of,
     types::ExprType,
 };
 
@@ -72,7 +72,7 @@ pub fn threading_module<T: Debugger + Sync>() -> Module<4, T> {
                             let old_update = on_update.clone();
 
                             *on_update = Arc::new(
-                                move |ctx: &Context<T>, value: TracedExpr<usize>| {
+                                move |ctx: &Context<T>, value: TracedExpr<VariableId>| {
                                     old_update(ctx, value.clone());
 
                                     evaluate_function_application(
@@ -134,7 +134,7 @@ pub fn threading_module<T: Debugger + Sync>() -> Module<4, T> {
                         }
                         _ => Err(EvaluationError::TypeError {
                             expected: ExprType::Int,
-                            actual: type_of::<_, _, RuntimeLookup>(
+                            actual: type_of(
                                 &ctx.expression_context.read(),
                                 &first.evaluated,
                             )

--- a/src/modules/threading.rs
+++ b/src/modules/threading.rs
@@ -10,7 +10,7 @@ use crate::{
         evaluate_function_application, Context, EvaluationError,
         FunctionDefinition, VariableId,
     },
-    typechecking::type_of,
+    typechecking::{type_of, TypingContext},
     types::ExprType,
 };
 
@@ -136,6 +136,7 @@ pub fn threading_module<T: Debugger + Sync>() -> Module<4, T> {
                             expected: ExprType::Int,
                             actual: type_of(
                                 &ctx.expression_context.read(),
+                                &TypingContext::new(),
                                 &first.evaluated,
                             )
                             .unwrap(),

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -2,7 +2,7 @@ use bimap::BiMap;
 
 use crate::{
     debugging::Debugger,
-    interpreter::Context,
+    interpreter::{Context, VariableId},
     modules::{
         base::base_module, bool::bool_module, io::io_module,
         lists::lists_module, math::math_module, reactive::reactive_module,
@@ -18,7 +18,7 @@ use crate::{
 ///
 pub fn ef3r_stdlib<T: Debugger + Send + Sync + 'static>(
     debugger: T,
-    symbol_table: BiMap<usize, QualifiedName>,
+    symbol_table: BiMap<VariableId, QualifiedName>,
 ) -> (Vec<ModuleData>, Context<T>) {
     // Lookup table for the interpreter
     let mut context = Context::init(debugger);

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -175,9 +175,14 @@ pub fn type_of<T: Debugger>(
     }
 }
 
+///
+/// Constrcut the union of two types.
+///
 fn union_type(t1: &ExprType, t2: &ExprType) -> ExprType {
     if t1 == t2 {
         t1.clone()
+    } else if *t1 == ExprType::Any || *t2 == ExprType::Any {
+        ExprType::Any
     } else {
         ExprType::Union(vec![t1.clone(), t2.clone()])
     }

--- a/src/typechecking.rs
+++ b/src/typechecking.rs
@@ -61,15 +61,21 @@ pub fn type_of<T: Debugger>(
                 &traced_expr1.evaluated,
             )?),
         )),
-        TracedExprRec::BuiltinFunction(fn_id) => Ok(ExprType::Func(
-            ctx.functions[*fn_id].1.argument_types.to_vec(),
-            Box::new(
-                ctx.functions
-                    .get(*fn_id)
-                    .map(|f| f.1.result_type.clone())
-                    .unwrap_or(ExprType::Any),
-            ),
-        )),
+        TracedExprRec::BuiltinFunction(fn_id) => {
+            let result = Ok(ExprType::Func(
+                ctx.functions[*fn_id].1.argument_types.to_vec(),
+                Box::new(
+                    ctx.functions
+                        .get(*fn_id)
+                        .map(|f| f.1.result_type.clone())
+                        .unwrap_or(ExprType::Any),
+                ),
+            ));
+
+            println!("Type of {:?} is {:?}", &fn_id, &result);
+
+            result
+        }
         TracedExprRec::JoinHandle(_) => Err(vec![]),
         TracedExprRec::Node(_) => Ok(ExprType::Node(Box::new(ExprType::Any))),
         TracedExprRec::Lambda(args, stmts, traced_expr) => {
@@ -104,6 +110,7 @@ pub fn type_of<T: Debugger>(
         // Note: This may need to be refined if we ever add implicit partial application.
         TracedExprRec::Apply(f, args) => {
             type_of::<T>(ctx, typing_context, &f.evaluated).and_then(|f_type| {
+                println!("Typechecked apply: {}", f_type);
                 match f_type {
                     ExprType::Func(_, return_type) => Ok(*return_type),
                     ExprType::Union(types) => {

--- a/tests/autocomplete.rs
+++ b/tests/autocomplete.rs
@@ -1,0 +1,22 @@
+use bimap::BiMap;
+use ef3r::{
+    debugging::NoOpDebugger, executable::load_efrs_source,
+    lsp::autocomplete::autocomplete,
+};
+
+#[test]
+fn test_list_autocomplete() {
+    let (context, statements) =
+        load_efrs_source(NoOpDebugger {}, "list(1, 2, 3)".to_string()).unwrap();
+
+    let expr_to_complete = statements[0].expr.clone();
+
+    let completions = autocomplete(&context, &expr_to_complete);
+
+    println!("Completions were: {:?}", completions);
+
+    // List methods should be included in completions
+    assert!(completions.contains(&"map".to_string()));
+    assert!(completions.contains(&"filter".to_string()));
+    assert!(completions.contains(&"fold".to_string()));
+}

--- a/tests/node_evaluation.rs
+++ b/tests/node_evaluation.rs
@@ -8,7 +8,7 @@ use ef3r::{
         combined_node, filter_node, fold_node, map_node, process_event_frame,
         Node,
     },
-    interpreter::{apply_traced, Context},
+    interpreter::{apply_traced, Context, VariableId},
     stdlib::ef3r_stdlib,
     types::ExprType,
 };
@@ -227,21 +227,22 @@ fn test_fold_node() {
         TracedExprRec::None.traced(),
     );
 
-    let folded_node_index =
-        fold_node(
-            &context,
-            Arc::new(on_update),
-            event_node_index,
-            TracedExprRec::Int(2).traced(),
-            Box::new(|_, acc: TracedExpr<usize>, event: TracedExpr<usize>| {
+    let folded_node_index = fold_node(
+        &context,
+        Arc::new(on_update),
+        event_node_index,
+        TracedExprRec::Int(2).traced(),
+        Box::new(
+            |_, acc: TracedExpr<VariableId>, event: TracedExpr<VariableId>| {
                 match (acc.evaluated, event.evaluated) {
                     (TracedExprRec::Int(a), TracedExprRec::Int(b)) => {
                         TracedExprRec::Int(a + b).traced()
                     }
                     _ => panic!("Expected integers"),
                 }
-            }),
-        );
+            },
+        ),
+    );
 
     let graph = context.graph.lock();
 

--- a/tests/statement_execution.rs
+++ b/tests/statement_execution.rs
@@ -5,17 +5,23 @@ use ef3r::ast::traced_expr::TracedExprRec;
 use ef3r::ast::Statement;
 use ef3r::debugging::NoOpDebugger;
 use ef3r::executable::load_efrs_source;
-use ef3r::interpreter::interpret;
+use ef3r::interpreter::{interpret, VariableId};
+use ef3r::modules::QualifiedName;
 use ef3r::stdlib::ef3r_stdlib;
 
 #[test]
 fn variable_assignment() {
     let (_, context) = ef3r_stdlib(NoOpDebugger::new(), BiMap::new());
 
+    let x = VariableId::new(
+        &mut context.expression_context.write(),
+        QualifiedName::unqualified("x".to_string()),
+    );
+
     let expression = RawExpr::int(3);
     let statement = Statement {
         location: None,
-        var: Some(0),
+        var: Some(x),
         type_annotation: None,
         expr: expression.clone(),
     };
@@ -27,7 +33,7 @@ fn variable_assignment() {
             .expression_context
             .read()
             .variables
-            .get(&0)
+            .get(&x)
             .unwrap()
             .evaluated,
         expression.from_raw().evaluated
@@ -38,15 +44,21 @@ fn variable_assignment() {
 fn reassignment_of_statement() {
     let (_, context) = ef3r_stdlib(NoOpDebugger::new(), BiMap::new());
 
+    let x = VariableId::new(
+        &mut context.expression_context.write(),
+        QualifiedName::unqualified("x".to_string()),
+    );
+
     let statement1 = Statement {
         location: None,
-        var: Some(0),
+        var: Some(x),
         type_annotation: None,
         expr: RawExpr::int(2),
     };
+
     let statement2 = Statement {
         location: None,
-        var: Some(0),
+        var: Some(x),
         type_annotation: None,
         expr: RawExpr::int(3),
     };
@@ -58,7 +70,7 @@ fn reassignment_of_statement() {
             .expression_context
             .read()
             .variables
-            .get(&0)
+            .get(&x)
             .unwrap()
             .evaluated,
         TracedExprRec::Int(3)

--- a/tests/typechecking.rs
+++ b/tests/typechecking.rs
@@ -1,0 +1,79 @@
+use ef3r::{
+    debugging::NoOpDebugger,
+    executable::load_efrs_source,
+    typechecking::{typecheck, TypingContext},
+};
+
+#[test]
+fn test_illegal_op() {
+    let src = r#"x = 2 + "3";"#.to_string();
+
+    let (expr_context, statements) =
+        load_efrs_source(NoOpDebugger {}, src).unwrap();
+
+    let errors = typecheck(
+        &expr_context.expression_context.read(),
+        &mut TypingContext::new(),
+        statements,
+    );
+
+    assert!(!errors.is_empty());
+}
+
+#[test]
+fn test_legal_op() {
+    let src = r#"x = 2 + 3;"#.to_string();
+
+    let (expr_context, statements) =
+        load_efrs_source(NoOpDebugger {}, src).unwrap();
+
+    let errors = typecheck(
+        &expr_context.expression_context.read(),
+        &mut TypingContext::new(),
+        statements,
+    );
+
+    assert!(errors.is_empty());
+}
+
+#[test]
+fn test_complex_program() {
+    let src = r#"
+        x = 42;
+        y = x + 10;
+        z = { n -> n + y };
+        result = z(5);"#
+        .to_string();
+
+    let (expr_context, statements) =
+        load_efrs_source(NoOpDebugger {}, src).unwrap();
+
+    let errors = typecheck(
+        &expr_context.expression_context.read(),
+        &mut TypingContext::new(),
+        statements,
+    );
+
+    assert!(errors.is_empty());
+}
+
+#[test]
+fn test_complex_program_with_error() {
+    let src = r#"
+        x = 42;
+        y = x + "not a number";
+        z = { n -> n + n };
+        result = z(5);"#
+        .to_string();
+
+    let (expr_context, statements) =
+        load_efrs_source(NoOpDebugger {}, src).unwrap();
+
+    let errors = typecheck(
+        &expr_context.expression_context.read(),
+        &mut TypingContext::new(),
+        statements,
+    );
+
+    assert!(!errors.is_empty());
+}


### PR DESCRIPTION
This patch implements a basic typechecker for ef3r.

This builds off of the previously implemented `type_of`, and iterates through the program to check that all expressions are well-typed, and match up with the user's specified type annotations, as well as going through and adding already typechecked variables to the "typing context" so that dependent expressions can be checked.

This patch also includes several refactorings to improve the readability / type safety of the codebase. In particular, `usize` identifiers have been replaced by specific meaningful structs such as `FunctionID`.